### PR TITLE
Replace getDensity.value and getSolarAbsoptance.value 

### DIFF
--- a/lib/measures/ExteriorWallThermalPropertiesMultiplier/measure.rb
+++ b/lib/measures/ExteriorWallThermalPropertiesMultiplier/measure.rb
@@ -232,8 +232,8 @@ class ExteriorWallThermalPropertiesMultiplier < OpenStudio::Measure::ModelMeasur
         new_construction.setLayer(lay_index, new_layer)
         # calculate properties of new layer and output nice names
         final_r_val[con_index][lay_index] = new_construction.layers[lay_index].to_OpaqueMaterial.get.thermalResistance if layer.to_OpaqueMaterial.is_initialized
-        final_sol_abs[con_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.getSolarAbsorptance.value if lay_index == 0 && layer.to_StandardOpaqueMaterial.is_initialized
-        final_thm_mass[con_index][lay_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.getDensity.value if layer.to_StandardOpaqueMaterial.is_initialized
+        final_sol_abs[con_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.solarAbsorptance if lay_index == 0 && layer.to_StandardOpaqueMaterial.is_initialized
+        final_thm_mass[con_index][lay_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.density if layer.to_StandardOpaqueMaterial.is_initialized
         final_r_val_d[con_index][lay_index] = neat_numbers(final_r_val[con_index][lay_index])
         final_sol_abs_d[con_index] = neat_numbers(final_sol_abs[con_index]) if lay_index == 0 && layer.to_StandardOpaqueMaterial.is_initialized
         final_thm_mass_d[con_index][lay_index] = neat_numbers(final_thm_mass[con_index][lay_index]) if layer.to_StandardOpaqueMaterial.is_initialized

--- a/lib/measures/ExteriorWallThermalPropertiesPercentChange/measure.rb
+++ b/lib/measures/ExteriorWallThermalPropertiesPercentChange/measure.rb
@@ -222,8 +222,8 @@ class ExteriorWallThermalPropertiesPercentChange < OpenStudio::Measure::ModelMea
         new_construction.setLayer(lay_index, new_layer)
         # calculate properties of new layer and output nice names
         final_r_val[con_index][lay_index] = new_construction.layers[lay_index].to_OpaqueMaterial.get.thermalResistance if layer.to_OpaqueMaterial.is_initialized
-        final_sol_abs[con_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.getSolarAbsorptance.value if lay_index == 0 && layer.to_StandardOpaqueMaterial.is_initialized
-        final_thm_mass[con_index][lay_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.getDensity.value if layer.to_StandardOpaqueMaterial.is_initialized
+        final_sol_abs[con_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.solarAbsorptance if lay_index == 0 && layer.to_StandardOpaqueMaterial.is_initialized
+        final_thm_mass[con_index][lay_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.density if layer.to_StandardOpaqueMaterial.is_initialized
         final_r_val_d[con_index][lay_index] = neat_numbers(final_r_val[con_index][lay_index])
         final_sol_abs_d[con_index] = neat_numbers(final_sol_abs[con_index]) if lay_index == 0 && layer.to_StandardOpaqueMaterial.is_initialized
         final_thm_mass_d[con_index][lay_index] = neat_numbers(final_thm_mass[con_index][lay_index]) if layer.to_StandardOpaqueMaterial.is_initialized

--- a/lib/measures/RoofThermalPropertiesMultiplier/measure.rb
+++ b/lib/measures/RoofThermalPropertiesMultiplier/measure.rb
@@ -232,8 +232,8 @@ class RoofThermalPropertiesMultiplier < OpenStudio::Measure::ModelMeasure
         new_construction.setLayer(lay_index, new_layer)
         # calculate properties of new layer and output nice names
         final_r_val[con_index][lay_index] = new_construction.layers[lay_index].to_OpaqueMaterial.get.thermalResistance if layer.to_OpaqueMaterial.is_initialized
-        final_sol_abs[con_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.getSolarAbsorptance.value if lay_index == 0 && layer.to_StandardOpaqueMaterial.is_initialized
-        final_thm_mass[con_index][lay_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.getDensity.value if layer.to_StandardOpaqueMaterial.is_initialized
+        final_sol_abs[con_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.solarAbsorptance if lay_index == 0 && layer.to_StandardOpaqueMaterial.is_initialized
+        final_thm_mass[con_index][lay_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.density if layer.to_StandardOpaqueMaterial.is_initialized
         final_r_val_d[con_index][lay_index] = neat_numbers(final_r_val[con_index][lay_index])
         final_sol_abs_d[con_index] = neat_numbers(final_sol_abs[con_index]) if lay_index == 0 && layer.to_StandardOpaqueMaterial.is_initialized
         final_thm_mass_d[con_index][lay_index] = neat_numbers(final_thm_mass[con_index][lay_index]) if layer.to_StandardOpaqueMaterial.is_initialized

--- a/lib/measures/RoofThermalPropertiesPercentChange/measure.rb
+++ b/lib/measures/RoofThermalPropertiesPercentChange/measure.rb
@@ -222,8 +222,8 @@ class RoofThermalPropertiesPercentChange < OpenStudio::Measure::ModelMeasure
         new_construction.setLayer(lay_index, new_layer)
         # calculate properties of new layer and output nice names
         final_r_val[con_index][lay_index] = new_construction.layers[lay_index].to_OpaqueMaterial.get.thermalResistance if layer.to_OpaqueMaterial.is_initialized
-        final_sol_abs[con_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.getSolarAbsorptance.value if lay_index == 0 && layer.to_StandardOpaqueMaterial.is_initialized
-        final_thm_mass[con_index][lay_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.getDensity.value if layer.to_StandardOpaqueMaterial.is_initialized
+        final_sol_abs[con_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.solarAbsorptance if lay_index == 0 && layer.to_StandardOpaqueMaterial.is_initialized
+        final_thm_mass[con_index][lay_index] = new_construction.layers[lay_index].to_StandardOpaqueMaterial.get.density if layer.to_StandardOpaqueMaterial.is_initialized
         final_r_val_d[con_index][lay_index] = neat_numbers(final_r_val[con_index][lay_index])
         final_sol_abs_d[con_index] = neat_numbers(final_sol_abs[con_index]) if lay_index == 0 && layer.to_StandardOpaqueMaterial.is_initialized
         final_thm_mass_d[con_index][lay_index] = neat_numbers(final_thm_mass[con_index][lay_index]) if layer.to_StandardOpaqueMaterial.is_initialized


### PR DESCRIPTION
**Steps to find the solution**

1. go to the [OpenStudio SDK documentation](https://s3.amazonaws.com/openstudio-sdk-documentation/index.html)
2. select v3.1.0 and click on model
3. go to the source code and check which class is calling the method (in our example, the class is StandardOpaqueMaterial)
4. search for the class in the documentation
5. check if there’s a correspondent method that replaces the one that is failing. `getSolarAbsortance` and `getDensity`, in this case. (If you search by these methods in the v2.7.1 docs, you'll notice that they return ab optional type. that’s why in the source code it looks like `<methodName>.get`). The closest correspondences in v3.1.0 are `solarAbsortance` and `density`.