### PR TITLE
update Gemfile and gemspec to match model articulation repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # OpenStudio Calibration Measures Gem
 
+## Version 0.9.0
+* Updating dependencies and licenses for OpenStudio 3.7 (upgrade to standards gem 0.5.0, extension gem 0.7.0)
+* Fixed [#54]( https://github.com/NREL/openstudio-calibration-gem/issues/54 ), OS API changes break some measures
+
 ## Version 0.8.0
 * Fixed [#52]( https://github.com/NREL/openstudio-calibration-gem/pull/52 ), Specify date format in AddMonthlyUtilityData
 * Fixed [#55]( https://github.com/NREL/openstudio-calibration-gem/pull/55 ), Api change

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source 'http://rubygems.org'
 
+# Specify your gem's dependencies in openstudio-model-articulation.gemspec
 gemspec
 
 # Local gems are useful when developing and integrating the various dependencies.
@@ -10,7 +11,14 @@ gemspec
 # checkout the latest version (develop) from github.
 allow_local = ENV['FAVOR_LOCAL_GEMS']
 
+# Delete when these branchesa are merged and released
+# gem 'openstudio-extension', github: 'NREL/OpenStudio-extension-gem', branch: 'wenyi-bypass-zlib'
+# gem 'openstudio-standards', github: 'NREL/openstudio-standards', tag: 'v0.6.0.rc2', ref: "1c42110"
+# gem 'openstudio_measure_tester', :git => 'https://github.com/NREL/OpenStudio-measure-tester-gem.git', :branch => 'wenyi-dependencies-update'
+# gem 'openstudio-workflow', :git => 'https://github.com/NREL/OpenStudio-workflow-gem.git', :branch => 'develop', ref: "32126e9b9f6"
+# gem 'bcl', :git => 'https://github.com/wenyikuang/bcl-gem.git', :branch => 'develop'
 
+# Only uncomment if you need to test a different version of the extension gem
 if allow_local && File.exist?('../OpenStudio-extension-gem')
   gem 'openstudio-extension', path: '../OpenStudio-extension-gem'
 elsif allow_local

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,6 +1,6 @@
 //Jenkins pipelines are stored in shared libraries. Please see: https://github.com/NREL/cbci_jenkins_libs
  
-@Library('cbci_shared_libs') _
+@Library('cbci_shared_libs@developExtension') _
 
 // Build for PR to develop branch only. 
 if ((env.CHANGE_ID) && (env.CHANGE_TARGET) ) { // check if set

--- a/lib/measures/TimeseriesObjectiveFunction/measure.xml
+++ b/lib/measures/TimeseriesObjectiveFunction/measure.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <measure>
-  <schema_version>3.0</schema_version>
+  <schema_version>3.1</schema_version>
   <name>timeseries_objective_function</name>
   <uid>6804217d-4737-45f3-82df-b81393c29ce4</uid>
-  <version_id>535ddcca-3c28-484c-a2f3-e07eabff47d1</version_id>
-  <version_modified>20240428T231344Z</version_modified>
+  <version_id>23e1b99b-044e-456b-b6fe-8d53c3cf9417</version_id>
+  <version_modified>2024-07-11T19:58:13Z</version_modified>
   <xml_checksum>FFE04372</xml_checksum>
   <class_name>TimeseriesObjectiveFunction</class_name>
   <display_name>TimeSeries Objective Function</display_name>
@@ -405,12 +405,6 @@
       <checksum>BFFB1AA6</checksum>
     </file>
     <file>
-      <filename>timeseries_data.csv</filename>
-      <filetype>csv</filetype>
-      <usage_type>test</usage_type>
-      <checksum>3E875A75</checksum>
-    </file>
-    <file>
       <filename>README.md</filename>
       <filetype>md</filetype>
       <usage_type>readme</usage_type>
@@ -431,7 +425,13 @@
       <filename>report.html.erb</filename>
       <filetype>erb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>BBF56F62</checksum>
+      <checksum>8FAA542D</checksum>
+    </file>
+    <file>
+      <filename>timeseries_data.csv</filename>
+      <filetype>csv</filetype>
+      <usage_type>test</usage_type>
+      <checksum>3E875A75</checksum>
     </file>
   </files>
 </measure>

--- a/lib/measures/TimeseriesObjectiveFunction/resources/report.html.erb
+++ b/lib/measures/TimeseriesObjectiveFunction/resources/report.html.erb
@@ -19,6 +19,7 @@
 
 
 
+
 <!DOCTYPE html>
 <meta charset="utf-8">
 <style>

--- a/lib/measures/TimeseriesPlot/measure.xml
+++ b/lib/measures/TimeseriesPlot/measure.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <measure>
-  <schema_version>3.0</schema_version>
+  <schema_version>3.1</schema_version>
   <name>timeseries_plot</name>
   <uid>6804217d-4737-45f3-82df-b81393c29ce7</uid>
-  <version_id>47204e86-24f7-422e-925b-8dc8fc57fae6</version_id>
-  <version_modified>20240428T231345Z</version_modified>
+  <version_id>18f2eb4b-8ea6-492b-9eec-189733d7a975</version_id>
+  <version_modified>2024-07-11T19:58:13Z</version_modified>
   <xml_checksum>FFE04372</xml_checksum>
   <class_name>TimeseriesPlot</class_name>
   <display_name>Timeseries Plot</display_name>
@@ -100,10 +100,10 @@
   </attributes>
   <files>
     <file>
-      <filename>README.md.erb</filename>
-      <filetype>erb</filetype>
-      <usage_type>readmeerb</usage_type>
-      <checksum>703C9964</checksum>
+      <filename>LICENSE.md</filename>
+      <filetype>md</filetype>
+      <usage_type>license</usage_type>
+      <checksum>BFFB1AA6</checksum>
     </file>
     <file>
       <filename>README.md</filename>
@@ -112,10 +112,10 @@
       <checksum>A3A04D6D</checksum>
     </file>
     <file>
-      <filename>LICENSE.md</filename>
-      <filetype>md</filetype>
-      <usage_type>license</usage_type>
-      <checksum>BFFB1AA6</checksum>
+      <filename>README.md.erb</filename>
+      <filetype>erb</filetype>
+      <usage_type>readmeerb</usage_type>
+      <checksum>703C9964</checksum>
     </file>
     <file>
       <version>
@@ -132,7 +132,7 @@
       <filename>report.html.erb</filename>
       <filetype>erb</filetype>
       <usage_type>resource</usage_type>
-      <checksum>1C219163</checksum>
+      <checksum>A8E90964</checksum>
     </file>
   </files>
 </measure>

--- a/lib/measures/TimeseriesPlot/resources/report.html.erb
+++ b/lib/measures/TimeseriesPlot/resources/report.html.erb
@@ -19,6 +19,7 @@
 
 
 
+
 <!DOCTYPE html>
 <meta charset="utf-8">
 <style>

--- a/lib/measures/inspect_and_edit_parametric_schedules/measure.xml
+++ b/lib/measures/inspect_and_edit_parametric_schedules/measure.xml
@@ -114,7 +114,7 @@
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>3.1.0</identifier>
-        <min_compatible>3.1.0</min_compatible>
+        <min_compatible>3.8.0</min_compatible>
       </version>
       <filename>measure.rb</filename>
       <filetype>rb</filetype>

--- a/lib/measures/inspect_and_edit_parametric_schedules/measure.xml
+++ b/lib/measures/inspect_and_edit_parametric_schedules/measure.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <measure>
-  <schema_version>3.0</schema_version>
+  <schema_version>3.1</schema_version>
   <name>inspect_and_edit_parametric_schedules</name>
   <uid>4b5f610d-caac-47c2-bd5b-610e2fc0768e</uid>
-  <version_id>45aad22a-5db2-4eac-88aa-8aa7de0e7049</version_id>
-  <version_modified>20240428T231348Z</version_modified>
+  <version_id>cbb5a3da-7152-4bb9-832c-7028f7eda960</version_id>
+  <version_modified>2024-07-11T19:58:13Z</version_modified>
   <xml_checksum>57318DBA</xml_checksum>
   <class_name>InspectAndEditParametricSchedules</class_name>
   <display_name>Inspect and Edit Parametric Schedules</display_name>
@@ -75,22 +75,10 @@
   </attributes>
   <files>
     <file>
-      <filename>example_parametric_model.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>A0C68C28</checksum>
-    </file>
-    <file>
-      <filename>apply_measures_now.png</filename>
-      <filetype>png</filetype>
-      <usage_type>doc</usage_type>
-      <checksum>2D9A8051</checksum>
-    </file>
-    <file>
-      <filename>README.md.erb</filename>
-      <filetype>erb</filetype>
-      <usage_type>readmeerb</usage_type>
-      <checksum>F073FF6D</checksum>
+      <filename>LICENSE.md</filename>
+      <filetype>md</filetype>
+      <usage_type>license</usage_type>
+      <checksum>BFFB1AA6</checksum>
     </file>
     <file>
       <filename>README.md</filename>
@@ -99,10 +87,16 @@
       <checksum>A551610E</checksum>
     </file>
     <file>
-      <filename>LICENSE.md</filename>
-      <filetype>md</filetype>
-      <usage_type>license</usage_type>
-      <checksum>BFFB1AA6</checksum>
+      <filename>README.md.erb</filename>
+      <filetype>erb</filetype>
+      <usage_type>readmeerb</usage_type>
+      <checksum>F073FF6D</checksum>
+    </file>
+    <file>
+      <filename>apply_measures_now.png</filename>
+      <filetype>png</filetype>
+      <usage_type>doc</usage_type>
+      <checksum>2D9A8051</checksum>
     </file>
     <file>
       <version>
@@ -113,7 +107,13 @@
       <filename>measure.rb</filename>
       <filetype>rb</filetype>
       <usage_type>script</usage_type>
-      <checksum>EFE84854</checksum>
+      <checksum>5164BF8C</checksum>
+    </file>
+    <file>
+      <filename>example_parametric_model.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>A0C68C28</checksum>
     </file>
     <file>
       <filename>inspect_and_edit_parametric_schedules_test.rb</filename>

--- a/lib/measures/shift_hours_of_operation/measure.rb
+++ b/lib/measures/shift_hours_of_operation/measure.rb
@@ -469,7 +469,7 @@ class ShiftHoursOfOperation < OpenStudio::Measure::ModelMeasure
     # TODO: - need to address this error when manipulating schedules
     # [openstudio.standards.ScheduleRuleset] <1> Pre-interpolated processed hash for Large Office Bldg Equip Default Schedule has one or more out of order conflicts: [[3.5, 0.8], [4.5, 0.6], [5.0, 0.6], [7.0, 0.5], [9.0, 0.4], [6.0, 0.4], [10.0, 0.9], [16.5, 0.9], [17.5, 0.8], [18.5, 0.9], [21.5, 0.9]]. Method will stop because Error on Out of Order was set to true.
     # model_build_parametric_schedules
-    parametric_schedules = OpenstudioStandards::Schedules.model_apply_parametric_schedules(model, ramp_frequency: nil, infer_hoo_for_non_assigned_objects: true, error_on_out_of_order: true)
+    parametric_schedules = OpenstudioStandards::Schedules.model_apply_parametric_schedules(model, ramp_frequency: nil, infer_hoo_for_non_assigned_objects: true, error_on_out_of_order: false)
     runner.registerInfo("Created #{parametric_schedules.size} parametric schedules.")
 
     # report final condition of model

--- a/lib/measures/shift_hours_of_operation/measure.rb
+++ b/lib/measures/shift_hours_of_operation/measure.rb
@@ -10,14 +10,8 @@
 
 require 'openstudio-standards'
 
-# load OpenStudio measure libraries from openstudio-extension gem
-require 'openstudio-extension'
-require 'openstudio/extension/core/os_lib_helper_methods'
-
 # start the measure
 class ShiftHoursOfOperation < OpenStudio::Measure::ModelMeasure
-  # resource file modules
-  include OsLib_HelperMethods
 
   # human readable name
   def name
@@ -45,6 +39,8 @@ class ShiftHoursOfOperation < OpenStudio::Measure::ModelMeasure
     hoo_start_weekday.setDescription('Use decimal hours so an 1 hour and 15 minute shift would be 1.25. Positive value moves the hour of operation later')
     hoo_start_weekday.setDefaultValue(0.0)
     hoo_start_weekday.setUnits('Hours')
+    hoo_start_weekday.setMinValue(-24.0)
+    hoo_start_weekday.setMaxValue(24.0)
     args << hoo_start_weekday
 
     # delta hoo_dur for weekday
@@ -53,6 +49,8 @@ class ShiftHoursOfOperation < OpenStudio::Measure::ModelMeasure
     hoo_dur_weekday.setDescription('Use decimal hours so an 1 hour and 15 minute would be 1.25. Positive value makes the hour of operation longer.')
     hoo_dur_weekday .setDefaultValue(0.0)
     hoo_dur_weekday.setUnits('Hours')
+    hoo_dur_weekday.setMinValue(-24.0)
+    hoo_dur_weekday.setMaxValue(24.0)
     args << hoo_dur_weekday
 
     # TODO: - could include every day of the week
@@ -63,6 +61,8 @@ class ShiftHoursOfOperation < OpenStudio::Measure::ModelMeasure
     hoo_start_saturday.setDescription('Use decimal hours so an 1 hour and 15 minute shift would be 1.25. Positive value moves the hour of operation later')
     hoo_start_saturday.setDefaultValue(0.0)
     hoo_start_saturday.setUnits('Hours')
+    hoo_start_saturday.setMinValue(-24.0)
+    hoo_start_saturday.setMaxValue(24.0)
     args << hoo_start_saturday
 
     # delta hoo_dur for saturday
@@ -71,6 +71,8 @@ class ShiftHoursOfOperation < OpenStudio::Measure::ModelMeasure
     hoo_dur_saturday.setDescription('Use decimal hours so an 1 hour and 15 minute would be 1.25. Positive value makes the hour of operation longer.')
     hoo_dur_saturday.setDefaultValue(0.0)
     hoo_dur_saturday.setUnits('Hours')
+    hoo_dur_saturday.setMinValue(-24.0)
+    hoo_dur_saturday.setMaxValue(24.0)
     args << hoo_dur_saturday
 
     # delta hoo_start for sundays
@@ -79,6 +81,8 @@ class ShiftHoursOfOperation < OpenStudio::Measure::ModelMeasure
     hoo_start_sunday.setDescription('Use decimal hours so an 1 hour and 15 minute shift would be 1.25. Positive value moves the hour of operation later')
     hoo_start_sunday.setDefaultValue(0.0)
     hoo_start_sunday.setUnits('Hours')
+    hoo_start_sunday.setMinValue(-24.0)
+    hoo_start_sunday.setMaxValue(24.0)
     args << hoo_start_sunday
 
     # delta hoo_dur for sunday
@@ -87,6 +91,8 @@ class ShiftHoursOfOperation < OpenStudio::Measure::ModelMeasure
     hoo_dur_sunday.setDescription('Use decimal hours so an 1 hour and 15 minute would be 1.25. Positive value makes the hour of operation longer.')
     hoo_dur_sunday.setDefaultValue(0.0)
     hoo_dur_sunday.setUnits('Hours')
+    hoo_dur_sunday.setMinValue(-24.0)
+    hoo_dur_sunday.setMaxValue(24.0)
     args << hoo_dur_sunday
 
     # TODO: - could include start and end days to have delta or absolute values applied to. (maybe decimal between 1.0 and 13.0 month where 3.50 would be March 15th)
@@ -111,6 +117,8 @@ class ShiftHoursOfOperation < OpenStudio::Measure::ModelMeasure
     fraction_of_daily_occ_range.setDescription('This determine what fraction of occupancy be considered operating conditions. This fraction is normalized to expanded to range seen over the full year and does not necessary equal fraction of design occupancy. This value should be between 0 and 1.0 and is only used if dynamically generated parametric schedules are used.')
     fraction_of_daily_occ_range.setDefaultValue(0.25)
     fraction_of_daily_occ_range.setUnits('Hours')
+    fraction_of_daily_occ_range.setMinValue(0.0)
+    fraction_of_daily_occ_range.setMaxValue(1.0)
     args << fraction_of_daily_occ_range
 
     # argument to choose hour of operation variable method
@@ -150,7 +158,7 @@ class ShiftHoursOfOperation < OpenStudio::Measure::ModelMeasure
         runner.registerWarning("Hours of Operation Schedule is not set for #{space.name}.")
         next
       end
-      hours_of_operation_hash = standard.space_hours_of_operation(space)
+      hours_of_operation_hash = OpenstudioStandards::Space.space_hours_of_operation(space)
       hours_of_operation_hash.each do |hoo_key, val|
         if val[:hoo_hours] == 0.0
           hoo_summary_hash[:zero_hoo] << val[:hoo_hours]
@@ -390,22 +398,15 @@ class ShiftHoursOfOperation < OpenStudio::Measure::ModelMeasure
     super(model, runner, user_arguments)
 
     # assign the user inputs to variables
-    args = OsLib_HelperMethods.createRunVariables(runner, model, user_arguments, arguments(model))
+    args = runner.getArgumentValues(arguments(model), user_arguments)
+    args = Hash[args.collect{ |k, v| [k.to_s, v] }]
     if !args then return false end
 
-    # check expected values of double arguments
-    fraction = OsLib_HelperMethods.checkDoubleAndIntegerArguments(runner, user_arguments, 'min' => 0.0, 'max' => 1.0, 'min_eq_bool' => true, 'max_eq_bool' => true, 'arg_array' => ['fraction_of_daily_occ_range'])
+    # open channel to log messages
+    reset_log
 
-    neg_24__24 = ['hoo_start_weekday',
-                  'hoo_dur_weekday',
-                  'hoo_start_saturday',
-                  'hoo_dur_saturday',
-                  'hoo_start_sunday',
-                  'hoo_dur_sunday']
-    time_hours = OsLib_HelperMethods.checkDoubleAndIntegerArguments(runner, user_arguments, 'min' => -24.0, 'max' => 24.0, 'min_eq_bool' => true, 'max_eq_bool' => true, 'arg_array' => neg_24__24)
-
-    # setup log messages that will come from standards
-    OsLib_HelperMethods.setup_log_msgs(runner, true) # bool is debug
+    # Turn debugging output on/off
+    debug = false
 
     # load standards
     standard = Standard.build('90.1-2004') # selected template doesn't matter
@@ -414,19 +415,19 @@ class ShiftHoursOfOperation < OpenStudio::Measure::ModelMeasure
       # infer hours of operation for the building
       # @param fraction_of_daily_occ_range [Double] fraction above/below daily min range required to start and end hours of operation
       occ_fraction = args['fraction_of_daily_occ_range']
-      standard.model_infer_hours_of_operation_building(model, fraction_of_daily_occ_range: occ_fraction, gen_occ_profile: true)
+      OpenstudioStandards::Schedules.model_infer_hours_of_operation_building(model, fraction_of_daily_occ_range: occ_fraction, gen_occ_profile: true)
       runner.registerInfo('Inferring initial hours of operation for the building and generating parametric profile formulas.')
 
       # report back hours of operation
       initial_hoo_range = []
-      hours_of_operation_hash_test = standard.space_hours_of_operation(model.getSpaces.first)
+      hours_of_operation_hash_test = OpenstudioStandards::Space.space_hours_of_operation(model.getSpaces.first)
       hours_of_operation_hash_test.each do |hoo_key, val|
         initial_hoo_range << val[:hoo_hours]
         runner.registerInfo("For Profile Index #{hoo_key} hours of operation run for #{val[:hoo_hours]} hours, from #{val[:hoo_start]} to #{val[:hoo_end]} and is used for #{val[:days_used].size} days of the year.")
       end
 
       # model_setup_parametric_schedules
-      standard.model_setup_parametric_schedules(model, gather_data_only: false, hoo_var_method: args['hoo_var_method'])
+      OpenstudioStandards::Schedules.model_setup_parametric_schedules(model, gather_data_only: false, hoo_var_method: args['hoo_var_method'])
     end
 
     # report initial condition of model
@@ -446,7 +447,7 @@ class ShiftHoursOfOperation < OpenStudio::Measure::ModelMeasure
         runner.registerWarning("Hours of Operation Schedule is not set for #{space.name}.")
         next
       end
-      hours_of_operation_hash = standard.space_hours_of_operation(space)
+      hours_of_operation_hash = OpenstudioStandards::Space.space_hours_of_operation(space)
       used_hoo_sch_sets[hours_of_operation.get] = hours_of_operation_hash
     end
 
@@ -468,7 +469,7 @@ class ShiftHoursOfOperation < OpenStudio::Measure::ModelMeasure
     # TODO: - need to address this error when manipulating schedules
     # [openstudio.standards.ScheduleRuleset] <1> Pre-interpolated processed hash for Large Office Bldg Equip Default Schedule has one or more out of order conflicts: [[3.5, 0.8], [4.5, 0.6], [5.0, 0.6], [7.0, 0.5], [9.0, 0.4], [6.0, 0.4], [10.0, 0.9], [16.5, 0.9], [17.5, 0.8], [18.5, 0.9], [21.5, 0.9]]. Method will stop because Error on Out of Order was set to true.
     # model_build_parametric_schedules
-    parametric_schedules = standard.model_apply_parametric_schedules(model, ramp_frequency: nil, infer_hoo_for_non_assigned_objects: true, error_on_out_of_order: true)
+    parametric_schedules = OpenstudioStandards::Schedules.model_apply_parametric_schedules(model, ramp_frequency: nil, infer_hoo_for_non_assigned_objects: true, error_on_out_of_order: true)
     runner.registerInfo("Created #{parametric_schedules.size} parametric schedules.")
 
     # report final condition of model
@@ -479,8 +480,9 @@ class ShiftHoursOfOperation < OpenStudio::Measure::ModelMeasure
       runner.registerFinalCondition("Across the building the hours of operation range from #{hoo_summary_hash[:final_hoo_dur_range].min} hours to #{hoo_summary_hash[:final_hoo_dur_range].max} hours. Start of hours of operation range from #{hoo_summary_hash[:final_hoo_start_range].min} to #{hoo_summary_hash[:final_hoo_start_range].max}.")
     end
 
-    # get log messages (if debug in setup is true this will fail for error)
-    OsLib_HelperMethods.log_msgs
+    # gather log
+    log_messages_to_runner(runner, debug)
+    reset_log
 
     # TODO: - adding hours of operation to a schedule that doesn't have them to start with, like a sunday, can be problematic
     # todo - start of day may not be reliable and there may not be formula inputs to show what occupied behavior is

--- a/lib/measures/shift_hours_of_operation/measure.xml
+++ b/lib/measures/shift_hours_of_operation/measure.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0"?>
 <measure>
-  <schema_version>3.0</schema_version>
+  <schema_version>3.1</schema_version>
   <name>shift_hours_of_operation</name>
   <uid>e8ae02a4-4be2-45c3-b85b-2a1d94662653</uid>
-  <version_id>c9fa50f9-123a-462b-8280-ca18cf7cf1ef</version_id>
-  <version_modified>20240428T231348Z</version_modified>
+  <version_id>b960e0ec-2792-4cb7-aadc-e29fa84034bb</version_id>
+  <version_modified>2024-07-11T19:58:17Z</version_modified>
   <xml_checksum>4098406A</xml_checksum>
   <class_name>ShiftHoursOfOperation</class_name>
   <display_name>Shift Hours of Operation</display_name>
@@ -20,6 +20,8 @@
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>0</default_value>
+      <min_value>-24.000000</min_value>
+      <max_value>24.000000</max_value>
     </argument>
     <argument>
       <name>hoo_dur_weekday</name>
@@ -30,6 +32,8 @@
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>0</default_value>
+      <min_value>-24.000000</min_value>
+      <max_value>24.000000</max_value>
     </argument>
     <argument>
       <name>hoo_start_saturday</name>
@@ -40,6 +44,8 @@
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>0</default_value>
+      <min_value>-24.000000</min_value>
+      <max_value>24.000000</max_value>
     </argument>
     <argument>
       <name>hoo_dur_saturday</name>
@@ -50,6 +56,8 @@
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>0</default_value>
+      <min_value>-24.000000</min_value>
+      <max_value>24.000000</max_value>
     </argument>
     <argument>
       <name>hoo_start_sunday</name>
@@ -60,6 +68,8 @@
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>0</default_value>
+      <min_value>-24.000000</min_value>
+      <max_value>24.000000</max_value>
     </argument>
     <argument>
       <name>hoo_dur_sunday</name>
@@ -70,6 +80,8 @@
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>0</default_value>
+      <min_value>-24.000000</min_value>
+      <max_value>24.000000</max_value>
     </argument>
     <argument>
       <name>delta_values</name>
@@ -118,6 +130,8 @@
       <required>true</required>
       <model_dependent>false</model_dependent>
       <default_value>0.25</default_value>
+      <min_value>0.000000</min_value>
+      <max_value>1.000000</max_value>
     </argument>
     <argument>
       <name>hoo_var_method</name>
@@ -212,10 +226,16 @@
   </attributes>
   <files>
     <file>
-      <filename>example_model.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>BE467EF8</checksum>
+      <filename>LICENSE.md</filename>
+      <filetype>md</filetype>
+      <usage_type>license</usage_type>
+      <checksum>BFFB1AA6</checksum>
+    </file>
+    <file>
+      <filename>README.md</filename>
+      <filetype>md</filetype>
+      <usage_type>readme</usage_type>
+      <checksum>46CEB194</checksum>
     </file>
     <file>
       <filename>README.md.erb</filename>
@@ -224,10 +244,21 @@
       <checksum>232D0477</checksum>
     </file>
     <file>
-      <filename>target_hoo_from_model.osm</filename>
-      <filetype>osm</filetype>
-      <usage_type>test</usage_type>
-      <checksum>3F74E693</checksum>
+      <filename>.gitkeep</filename>
+      <filetype>gitkeep</filetype>
+      <usage_type>doc</usage_type>
+      <checksum>00000000</checksum>
+    </file>
+    <file>
+      <version>
+        <software_program>OpenStudio</software_program>
+        <identifier>3.1.0</identifier>
+        <min_compatible>3.8.0</min_compatible>
+      </version>
+      <filename>measure.rb</filename>
+      <filetype>rb</filetype>
+      <usage_type>script</usage_type>
+      <checksum>564F5547</checksum>
     </file>
     <file>
       <filename>SimpleModel.osm</filename>
@@ -242,22 +273,10 @@
       <checksum>03619D54</checksum>
     </file>
     <file>
-      <filename>.gitkeep</filename>
-      <filetype>gitkeep</filetype>
-      <usage_type>doc</usage_type>
-      <checksum>00000000</checksum>
-    </file>
-    <file>
-      <filename>README.md</filename>
-      <filetype>md</filetype>
-      <usage_type>readme</usage_type>
-      <checksum>46CEB194</checksum>
-    </file>
-    <file>
-      <filename>LICENSE.md</filename>
-      <filetype>md</filetype>
-      <usage_type>license</usage_type>
-      <checksum>BFFB1AA6</checksum>
+      <filename>example_model.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>BE467EF8</checksum>
     </file>
     <file>
       <filename>shift_hours_of_operation_test.rb</filename>
@@ -266,15 +285,10 @@
       <checksum>59E5AA36</checksum>
     </file>
     <file>
-      <version>
-        <software_program>OpenStudio</software_program>
-        <identifier>3.1.0</identifier>
-        <min_compatible>3.8.0</min_compatible>
-      </version>
-      <filename>measure.rb</filename>
-      <filetype>rb</filetype>
-      <usage_type>script</usage_type>
-      <checksum>B85FE950</checksum>
+      <filename>target_hoo_from_model.osm</filename>
+      <filetype>osm</filetype>
+      <usage_type>test</usage_type>
+      <checksum>3F74E693</checksum>
     </file>
   </files>
 </measure>

--- a/lib/measures/shift_hours_of_operation/measure.xml
+++ b/lib/measures/shift_hours_of_operation/measure.xml
@@ -269,7 +269,7 @@
       <version>
         <software_program>OpenStudio</software_program>
         <identifier>3.1.0</identifier>
-        <min_compatible>3.1.0</min_compatible>
+        <min_compatible>3.8.0</min_compatible>
       </version>
       <filename>measure.rb</filename>
       <filetype>rb</filetype>

--- a/openstudio-calibration.gemspec
+++ b/openstudio-calibration.gemspec
@@ -32,14 +32,14 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'bundler', '~> 2.4.10'
   spec.add_dependency 'openstudio-extension', '~> 0.8.0'
   spec.add_dependency 'openstudio-standards', '0.6.1'
-  spec.add_dependency 'openstudio_measure_tester', '~> 0.4.0'
-  spec.add_dependency 'openstudio-workflow', '~> 2.4.0'
-  spec.add_dependency 'bcl', '~> 0.8.0'
-  spec.add_dependency 'octokit', '4.18.0' # for change logs
+
+  # if we need the following dependencies pinned, 
+  # let's set them in extension-gem for next release
   spec.add_dependency 'multipart-post', '2.4.0'
-  spec.add_dependency 'parallel', '1.19.1'
   spec.add_dependency 'regexp_parser', '2.9.0'
   spec.add_dependency 'addressable', '2.8.1'
+
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'
+  spec.add_development_dependency 'octokit', '4.18.0' # for change logs
 end

--- a/openstudio-calibration.gemspec
+++ b/openstudio-calibration.gemspec
@@ -23,15 +23,23 @@ Gem::Specification.new do |spec|
   spec.files = `git ls-files -z`.split("\x0").reject do |f|
     f.match(%r{^(test|lib.measures.*tests|spec|features)/})
   end
-  spec.bindir        = 'exe'
-  spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
+  spec.bindir = 'exe'
+  spec.executables = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.required_ruby_version = '~> 2.7.0'
+  spec.required_ruby_version = '~> 3.2.2'
 
-  spec.add_dependency 'bundler', '~> 2.1'
-  spec.add_dependency 'openstudio-extension', '~> 0.7.0'
-  spec.add_dependency 'openstudio-standards', '~> 0.5.0'
+  spec.add_dependency 'bundler', '~> 2.4.10'
+  spec.add_dependency 'openstudio-extension', '~> 0.8.0'
+  spec.add_dependency 'openstudio-standards', '0.6.0'
+  spec.add_dependency 'openstudio_measure_tester', '~> 0.4.0'
+  spec.add_dependency 'openstudio-workflow', '~> 2.4.0'
+  spec.add_dependency 'bcl', '~> 0.8.0'
+  spec.add_dependency 'octokit', '4.18.0' # for change logs
+  spec.add_dependency 'multipart-post', '2.4.0'
+  spec.add_dependency 'parallel', '1.19.1'
+  spec.add_dependency 'regexp_parser', '2.9.0'
+  spec.add_dependency 'addressable', '2.8.1'
 
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'

--- a/openstudio-calibration.gemspec
+++ b/openstudio-calibration.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'bundler', '~> 2.4.10'
   spec.add_dependency 'openstudio-extension', '~> 0.8.0'
-  spec.add_dependency 'openstudio-standards', '0.6.0'
+  spec.add_dependency 'openstudio-standards', '0.6.1'
   spec.add_dependency 'openstudio_measure_tester', '~> 0.4.0'
   spec.add_dependency 'openstudio-workflow', '~> 2.4.0'
   spec.add_dependency 'bcl', '~> 0.8.0'

--- a/openstudio-calibration.gemspec
+++ b/openstudio-calibration.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'bundler', '~> 2.1'
   spec.add_dependency 'openstudio-extension', '~> 0.7.0'
-  spec.add_dependency 'openstudio-standards', '>= 0.5.0.rc1', '< 0.6.0'
+  spec.add_dependency 'openstudio-standards', '~> 0.5.0'
 
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.9'


### PR DESCRIPTION
Current Failing Tests
- [x] InspectAndEditParametricSchedules: only test errors getting optional not initialized on model_apply_parametric_schedules (follow up with Matt on this, did additional property para schedule inputs change?)
     - [ ] After I fixed that this shows next: XcelEDAReportingandQAQC_Test#test_example_model:
NoMethodError: undefined method `execAndReturnFirstDouble' for nil:NilClass
    :/ruby/3.2.0/gems/openstudio-standards-0.6.0.rc2/lib/openstudio-standards/qaqc/create_results.rb:54:in `make_qaqc_results_vector'.  (May be related to this issue https://github.com/NREL/OpenStudio/issues/5196)
- [ ] ShiftHoursOfOperation: 2 of 7 tests failed need to investigate more. The 2 fails test have variations on [openstudio.standards.Parametric.ScheduleDay] Pre-interpolated processed hash for Deck_Temperature_Default 1 has one or more out of order conflicts:
   

Pre release
- [ ] Try and fix open issues
- [ ] Make sure xml files updated to 3.8.0 where needed
- [ ] Update readme and change log